### PR TITLE
feat: add cpp project support(which MUST be built with cmake or vcpkg)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "glob",
  "log",
  "pathdiff",
+ "regex",
  "saphyr",
  "semver",
  "serde",

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -15,6 +15,7 @@ git2 = { version = "0.20.2", features = ["vendored-openssl"] }
 glob = "0.3.3"
 log = "0.4.27"
 pathdiff = "0.2.3"
+regex = "1.11.1"
 saphyr = "0.0.6"
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/resolver/src/context.rs
+++ b/crates/resolver/src/context.rs
@@ -104,6 +104,7 @@ impl Context {
             resolver::ResolverType::Rust => Box::new(resolver::rust::RustResolver),
             resolver::ResolverType::Nodejs => Box::new(resolver::nodejs::NodejsResolver),
             resolver::ResolverType::Python => Box::new(resolver::python::PythonResolver),
+            resolver::ResolverType::Cpp => Box::new(resolver::cpp::CppResolver),
         }
     }
 

--- a/crates/resolver/src/resolver/cpp.rs
+++ b/crates/resolver/src/resolver/cpp.rs
@@ -1,0 +1,260 @@
+use std::path::Path;
+
+use regex::Regex;
+
+use crate::{
+    config::{PackageConfig, ResolverConfig, VersionMode},
+    context,
+    error::ResolveError,
+    resolver::{ResolvedPackage, Resolver, ResolverType},
+    utils,
+};
+
+/// C++ resolver for CMake-based projects
+pub struct CppResolver;
+
+impl CppResolver {
+    /// Read version from CMakeLists.txt
+    fn read_cmake_version(&self, package_path: &Path) -> Result<String, ResolveError> {
+        let cmake_path = package_path.join("CMakeLists.txt");
+        if !cmake_path.exists() {
+            return Err(ResolveError::FileOrDirNotFound {
+                path: cmake_path.clone(),
+            });
+        }
+
+        let content = std::fs::read_to_string(&cmake_path)?;
+
+        // Match: project(...VERSION x.y.z...)
+        let re = Regex::new(r"project\s*\([^)]*VERSION\s+([\d.]+)").map_err(|e| {
+            ResolveError::ParseError {
+                path: cmake_path.clone(),
+                reason: format!("Invalid regex: {}", e),
+            }
+        })?;
+
+        let version = re
+            .captures(&content)
+            .and_then(|caps| caps.get(1))
+            .map(|m| m.as_str().to_string())
+            .ok_or_else(|| ResolveError::ParseError {
+                path: cmake_path.clone(),
+                reason: "VERSION not found in project() declaration".to_string(),
+            })?;
+
+        log::debug!("Read version {} from {:?}", version, cmake_path);
+        Ok(version)
+    }
+
+    /// Update version in CMakeLists.txt
+    fn update_cmake_version(
+        &self,
+        package_path: &Path,
+        new_version: &str,
+    ) -> Result<(), ResolveError> {
+        let cmake_path = package_path.join("CMakeLists.txt");
+        let content = std::fs::read_to_string(&cmake_path)?;
+
+        // Replace version in project() declaration
+        let re = Regex::new(r"(project\s*\([^)]*VERSION\s+)([\d.]+)").map_err(|e| {
+            ResolveError::ParseError {
+                path: cmake_path.clone(),
+                reason: format!("Invalid regex: {}", e),
+            }
+        })?;
+
+        let updated_content = re.replace(&content, |caps: &regex::Captures| {
+            format!("{}{}", &caps[1], new_version)
+        });
+
+        std::fs::write(&cmake_path, updated_content.as_ref())?;
+        log::info!("Updated {:?} to version {}", cmake_path, new_version);
+        Ok(())
+    }
+
+    /// Update version in vcpkg.json if it exists (optional)
+    fn update_vcpkg_version(
+        &self,
+        package_path: &Path,
+        new_version: &str,
+    ) -> Result<(), ResolveError> {
+        let vcpkg_path = package_path.join("vcpkg.json");
+
+        if !vcpkg_path.exists() {
+            log::debug!("Skipping optional file {:?} (not found)", vcpkg_path);
+            return Ok(());
+        }
+
+        let content = std::fs::read_to_string(&vcpkg_path)?;
+        let mut vcpkg_json: serde_json::Value =
+            serde_json::from_str(&content).map_err(|e| ResolveError::ParseError {
+                path: vcpkg_path.clone(),
+                reason: e.to_string(),
+            })?;
+
+        if let Some(obj) = vcpkg_json.as_object_mut() {
+            obj.insert(
+                "version".to_string(),
+                serde_json::Value::String(new_version.to_string()),
+            );
+        }
+
+        let updated_content =
+            serde_json::to_string_pretty(&vcpkg_json).map_err(|e| ResolveError::ParseError {
+                path: vcpkg_path.clone(),
+                reason: e.to_string(),
+            })?;
+
+        std::fs::write(&vcpkg_path, updated_content)?;
+        log::info!("Updated {:?} to version {}", vcpkg_path, new_version);
+        Ok(())
+    }
+}
+
+impl Resolver for CppResolver {
+    fn resolve(
+        &mut self,
+        root: &Path,
+        pkg_config: &PackageConfig,
+    ) -> Result<ResolvedPackage, ResolveError> {
+        let package_path = root.join(&pkg_config.path);
+        let version = self.read_cmake_version(&package_path)?;
+
+        // Extract project name from CMakeLists.txt
+        let cmake_path = package_path.join("CMakeLists.txt");
+        let content = std::fs::read_to_string(&cmake_path)?;
+
+        // Match: project(ProjectName ...)
+        let re = Regex::new(r"project\s*\(\s*(\w+)").map_err(|e| ResolveError::ParseError {
+            path: cmake_path.clone(),
+            reason: format!("Invalid regex: {}", e),
+        })?;
+
+        let name = re
+            .captures(&content)
+            .and_then(|caps| caps.get(1))
+            .map(|m| m.as_str().to_string())
+            .ok_or_else(|| ResolveError::ParseError {
+                path: cmake_path.clone(),
+                reason: "Project name not found in project() declaration".to_string(),
+            })?;
+
+        Ok(ResolvedPackage {
+            name,
+            version: semver::Version::parse(&version)?,
+            path: pkg_config.path.clone(),
+            private: false,
+        })
+    }
+
+    fn resolve_all(&mut self, root: &Path) -> Result<Vec<ResolvedPackage>, ResolveError> {
+        let cmake_path = root.join("CMakeLists.txt");
+        if !cmake_path.exists() {
+            log::warn!(
+                "Cannot resolve package in {}, CMakeLists.txt not found.",
+                root.display()
+            );
+            return Ok(vec![]);
+        }
+
+        // C++ projects typically don't have workspace concept like Rust/Node.js
+        // So we just resolve the single package at root
+        let package = self.resolve(
+            root,
+            &PackageConfig {
+                path: ".".into(),
+                resolver: ResolverType::Cpp,
+                version_mode: VersionMode::Semantic,
+                assets: vec![],
+            },
+        )?;
+
+        Ok(vec![package])
+    }
+
+    fn bump(
+        &mut self,
+        ctx: &context::Context,
+        root: &Path,
+        package: &ResolvedPackage,
+        version: &semver::Version,
+    ) -> Result<(), ResolveError> {
+        let bumped_version = version.to_string();
+        let package_path = root.join(&package.path);
+
+        if ctx.dry_run {
+            log::warn!(
+                "Skip bump for {} to version {} due to dry run",
+                package.name,
+                bumped_version
+            );
+            return Ok(());
+        }
+
+        // Update CMakeLists.txt (required)
+        self.update_cmake_version(&package_path, &bumped_version)?;
+
+        // Update vcpkg.json if it exists (optional)
+        self.update_vcpkg_version(&package_path, &bumped_version)?;
+
+        Ok(())
+    }
+
+    fn sort_packages(
+        &mut self,
+        _root: &Path,
+        _packages: &mut Vec<(String, PackageConfig)>,
+    ) -> Result<(), ResolveError> {
+        // C++ projects don't typically have internal package dependencies
+        // that need sorting, so this is a no-op
+        Ok(())
+    }
+
+    fn publish(
+        &mut self,
+        package: &ResolvedPackage,
+        resolver_config: &ResolverConfig,
+        dry_run: bool,
+    ) -> Result<(), ResolveError> {
+        if package.private {
+            log::warn!(
+                "Skip publish {} {} due to private flag",
+                package.name,
+                format_args!("v{}", package.version)
+            );
+            return Ok(());
+        }
+
+        log::info!("Running prepublish commands for {}", package.name);
+        for prepublish in &resolver_config.prepublish {
+            let args = prepublish.args.clone().unwrap_or_default();
+            if dry_run && !prepublish.dry_run.unwrap_or(false) {
+                log::warn!(
+                    "Skip prepublish command {} {} due to dry run",
+                    prepublish.command,
+                    args.join(" ")
+                );
+                continue;
+            }
+            log::info!("Running {} {}", prepublish.command, args.join(" "));
+            utils::run_command(prepublish, &package.path)?;
+        }
+
+        log::info!("Running publish commands for {}", package.name);
+        for publish in &resolver_config.publish {
+            let args = publish.args.clone().unwrap_or_default();
+            if dry_run && !publish.dry_run.unwrap_or(false) {
+                log::warn!(
+                    "Skip publish command {} {} due to dry run",
+                    publish.command,
+                    args.join(" ")
+                );
+                continue;
+            }
+            log::info!("Running {} {}", publish.command, args.join(" "));
+            utils::run_command(publish, &package.path)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/resolver/src/resolver/mod.rs
+++ b/crates/resolver/src/resolver/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 use core::fmt;
 use std::path::{Path, PathBuf};
 
+pub mod cpp;
 pub mod nodejs;
 pub mod python;
 pub mod rust;
@@ -28,6 +29,7 @@ pub enum ResolverType {
     Rust,
     Nodejs,
     Python,
+    Cpp,
 }
 
 impl fmt::Display for ResolverType {
@@ -36,6 +38,7 @@ impl fmt::Display for ResolverType {
             ResolverType::Rust => write!(f, "rust"),
             ResolverType::Nodejs => write!(f, "nodejs"),
             ResolverType::Python => write!(f, "python"),
+            ResolverType::Cpp => write!(f, "cpp"),
         }
     }
 }


### PR DESCRIPTION
This pull request adds support for C++ projects using CMake to the resolver crate. The main change is the introduction of a new `CppResolver`, which can read, update, and bump package versions in `CMakeLists.txt` and optionally in `vcpkg.json`. The resolver also supports running prepublish and publish commands for C++ packages. To enable this, the resolver type system and context have been updated to recognize and use the new C++ resolver.

**C++ Resolver Integration**

* Added a new `CppResolver` implementation in `crates/resolver/src/resolver/cpp.rs` that can read and update package versions from `CMakeLists.txt` and optionally `vcpkg.json`, and supports bumping and publishing C++ packages.
* Registered the new resolver type in the resolver system by adding `Cpp` to the `ResolverType` enum and updating its display implementation in `crates/resolver/src/resolver/mod.rs`. [[1]](diffhunk://#diff-b1c4ac6715833768a46fc95f6aabb4e96f548dd1b22f603c791d97fb049a2a6bR32) [[2]](diffhunk://#diff-b1c4ac6715833768a46fc95f6aabb4e96f548dd1b22f603c791d97fb049a2a6bR41)
* Made the new resolver available to the context by updating the resolver selection logic in `crates/resolver/src/context.rs`.

**Dependency Update**

* Added the `regex` crate to `crates/resolver/Cargo.toml` to support regular expression parsing in the new resolver.

**Module Structure**

* Exposed the new `cpp` module in the resolver module tree in `crates/resolver/src/resolver/mod.rs`.