### PR TITLE
feat: add C++ support in init command and update README

### DIFF
--- a/.changes/add-`cpp`-option-in-`init`-command.md
+++ b/.changes/add-`cpp`-option-in-`init`-command.md
@@ -1,0 +1,5 @@
+---
+semifold: "patch:feat"
+---
+
+add `cpp` option in `init` command, which was forgotten in the previous commits

--- a/.changes/update-readme-to-indicate-the-support-for-c++-projects.md
+++ b/.changes/update-readme-to-indicate-the-support-for-c++-projects.md
@@ -1,0 +1,5 @@
+---
+"@semifold/docs": "patch:chore"
+---
+
+update README to indicate the support for C++ projects, which was forgotten in the previous commits

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Languages supported:
 - [x] Rust
 - [x] Node.js
 - [x] Python
+- [x] C++
 - [ ] Go
 - [ ] Java
 - [ ] Kotlin

--- a/crates/semifold/src/cli/init.rs
+++ b/crates/semifold/src/cli/init.rs
@@ -18,6 +18,7 @@ pub(crate) enum ResolverType {
     Rust,
     Nodejs,
     Python,
+    Cpp,
 }
 
 impl From<ResolverType> for resolver::ResolverType {
@@ -26,6 +27,7 @@ impl From<ResolverType> for resolver::ResolverType {
             ResolverType::Rust => resolver::ResolverType::Rust,
             ResolverType::Nodejs => resolver::ResolverType::Nodejs,
             ResolverType::Python => resolver::ResolverType::Python,
+            ResolverType::Cpp => resolver::ResolverType::Cpp,
         }
     }
 }
@@ -36,6 +38,7 @@ impl std::fmt::Display for ResolverType {
             ResolverType::Rust => write!(f, "Rust"),
             ResolverType::Nodejs => write!(f, "Nodejs"),
             ResolverType::Python => write!(f, "Python"),
+            ResolverType::Cpp => write!(f, "Cpp"),
         }
     }
 }
@@ -163,7 +166,19 @@ pub(crate) fn run(init: &Init, ctx: &context::Context) -> anyhow::Result<()> {
                     },
                     prepublish: vec![],
                     publish: vec![],
-                    post_version: vec![]
+                    post_version: vec![],
+                },
+            ),
+            ResolverType::Cpp => (
+                ResolverTypeEnum::Cpp,
+                ResolverConfig {
+                    pre_check: PreCheckConfig {
+                        url: String::new(),
+                        extra_headers: BTreeMap::new(),
+                    },
+                    prepublish: vec![],
+                    publish: vec![],
+                    post_version: vec![],
                 },
             ),
         }
@@ -207,6 +222,19 @@ pub(crate) fn run(init: &Init, ctx: &context::Context) -> anyhow::Result<()> {
                     acc.entry(pkg.name.clone()).or_insert(PackageConfig {
                         path: pkg.path.clone(),
                         resolver: resolver::ResolverType::Python,
+                        version_mode: VersionMode::Semantic,
+                        assets: vec![],
+                    });
+                });
+                Ok::<_, ResolveError>(acc)
+            }
+            ResolverType::Cpp => {
+                let mut resolver = resolver::cpp::CppResolver;
+                let packages = resolver.resolve_all(&target_dir)?;
+                packages.into_iter().for_each(|pkg| {
+                    acc.entry(pkg.name.clone()).or_insert(PackageConfig {
+                        path: pkg.path.clone(),
+                        resolver: resolver::ResolverType::Cpp,
                         version_mode: VersionMode::Semantic,
                         assets: vec![],
                     });


### PR DESCRIPTION
This pull request adds support for C++ projects to the `init` command, which was previously missing. It updates the codebase to recognize and handle C++ as a supported language, and also updates the documentation to reflect this new support.

Support for C++ projects:

* Added `Cpp` variant to the `ResolverType` enum and updated all relevant match arms and conversions in `crates/semifold/src/cli/init.rs` to handle C++ projects. [[1]](diffhunk://#diff-8c3d74ba935c03d8746a4b4b52862a2b0f289689aca0e2c49d69b25b4bcc78abR21) [[2]](diffhunk://#diff-8c3d74ba935c03d8746a4b4b52862a2b0f289689aca0e2c49d69b25b4bcc78abR30) [[3]](diffhunk://#diff-8c3d74ba935c03d8746a4b4b52862a2b0f289689aca0e2c49d69b25b4bcc78abR41)
* Implemented logic for initializing and resolving C++ projects in the `run` function of `init.rs`, including configuration and package resolution. [[1]](diffhunk://#diff-8c3d74ba935c03d8746a4b4b52862a2b0f289689aca0e2c49d69b25b4bcc78abL166-R181) [[2]](diffhunk://#diff-8c3d74ba935c03d8746a4b4b52862a2b0f289689aca0e2c49d69b25b4bcc78abR231-R243)
* Added a changelog entry documenting the addition of the `cpp` option to the `init` command.

Documentation updates:

* Updated the `README.md` to indicate support for C++ projects in the list of supported languages.
* Added a changelog entry for the README update to mention C++ support.